### PR TITLE
fix: retry exception handling

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@pm4ml/mcm-client",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "Client service for Connection Manager API",
   "main": "src/index.js",
   "types": "dist/index.d.ts",

--- a/src/lib/requests/common.js
+++ b/src/lib/requests/common.js
@@ -34,6 +34,10 @@ class HTTPResponseError extends Error {
     toString() {
         return util.inspect(this[respErrSym]);
     }
+
+    toJSON() {
+        return JSON.stringify(this[respErrSym]);
+    }
 }
 
 // Strip all beginning and end forward-slashes from each of the arguments, then join all the

--- a/src/lib/requests/common.js
+++ b/src/lib/requests/common.js
@@ -34,10 +34,6 @@ class HTTPResponseError extends Error {
     toString() {
         return util.inspect(this[respErrSym]);
     }
-
-    toJSON() {
-        return JSON.stringify(this[respErrSym]);
-    }
 }
 
 // Strip all beginning and end forward-slashes from each of the arguments, then join all the

--- a/src/lib/requests/jwt.js
+++ b/src/lib/requests/jwt.js
@@ -67,9 +67,9 @@ class JWTSingleton {
             }
 
             return data.access_token;
-        } catch (err) {
-            this._logger.push({ err }).log('Error Login');
-            throw err;
+        } catch (error) {
+            this._logger.push({ error }).log('Error Login');
+            throw error;
         }
     }
 }

--- a/src/lib/requests/requests.js
+++ b/src/lib/requests/requests.js
@@ -96,10 +96,10 @@ class Requests {
                   if ([401, 403].includes(statusCode)) {
                       this.logger.push({ error }).log(`Retrying login due to error statusCode: ${statusCode}`);
                       const JWT = new JWTSingleton();
-                      return JWT.login().then(() => error).catch(bail);
+                      return JWT.login().then(() => { throw error }, bail);
                   }
 
-                  return error;
+                  throw error;
               });
         }, {
             retries: this.retries,

--- a/src/lib/requests/requests.js
+++ b/src/lib/requests/requests.js
@@ -76,7 +76,7 @@ class Requests {
     }
 
     async #sendRequestWithRetry(url, method, body = null) {
-        return await retry(async (bail) => {
+        return await retry(async () => {
             const headers = this._buildHeaders();
             const uri = buildUrl(this.hubEndpoint, url);
             const reqOpts = {
@@ -87,20 +87,18 @@ class Requests {
             };
             this.logger.push({ reqOpts }).log(`Executing HTTP ${method}`);
 
-            return request({ ...reqOpts, agent: this.agent })
-              .then(throwOrJson)
-              .catch((error) => {
-                  this.logger.push({ error }).log(`Error attempting HTTP ${method}`);
-
-                  const { statusCode } = error?.getData?.().res || error || {};
-                  if ([401, 403].includes(statusCode)) {
-                      this.logger.push({ error }).log(`Retrying login due to error statusCode: ${statusCode}`);
-                      const JWT = new JWTSingleton();
-                      return JWT.login().then(() => { throw error }, bail);
-                  }
-
-                  throw error;
-              });
+            try {
+                return throwOrJson(await request({ ...reqOpts, agent: this.agent }));
+            } catch (error) {
+                const { statusCode } = error?.getData?.().res || error || {};
+                this.logger.push({ error }).log(`Error attempting HTTP ${method} statusCode: ${statusCode}`);
+                if ([401, 403].includes(statusCode)) {
+                    this.logger.log(`Retrying login due to error statusCode: ${statusCode}`);
+                    const JWT = new JWTSingleton();
+                    await JWT.login();
+                }
+                throw error;
+            }
         }, {
             retries: this.retries,
         });


### PR DESCRIPTION
- fix issue where `onRetry` cannot be async and causes server crash due to unhandled promise exception.
- align error logging to use the same property `error` for the error
- do not stringify `HTTPResponseError` in the log