### PR TITLE
feat: add jest test-coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,5 @@
 node_modules/
 .swp
 src/junit.xml
+junit.xml
+coverage/

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,0 +1,55 @@
+/**
+ * For a detailed explanation regarding each configuration property, visit:
+ * https://jestjs.io/docs/configuration
+ */
+
+/** @type {import('jest').Config} */
+const config = {
+
+  reporters: [
+    'default',
+    ['jest-junit', {outputDirectory: 'reports', outputName: 'report.xml'}],
+  ],
+ 
+  // Automatically clear mock calls, instances, contexts and results before every test
+  clearMocks: true,
+
+  // Indicates whether the coverage information should be collected while executing the test
+  collectCoverage: true,
+
+  // The directory where Jest should output its coverage files
+  coverageDirectory: "coverage",
+
+  // Indicates which provider should be used to instrument code for coverage
+  coverageProvider: "v8",
+
+  // A list of reporter names that Jest uses when writing coverage reports
+  coverageReporters: [
+    "json",
+    "text",
+    "lcov",
+    'text-summary'
+  ],
+
+  // An object that configures minimum threshold enforcement for coverage results
+  coverageThreshold: {
+    global: {
+      statements: 50,
+      functions: 50,
+      branches: 50,
+      lines: 50
+    }
+  },
+
+  // The test environment that will be used for testing
+  testEnvironment: "jest-environment-node",
+
+  // An array of regexp pattern strings that are matched against all source file paths, matched files will skip transformation
+  transformIgnorePatterns: [
+    "/node_modules/",
+    // "\\.pnp\\.[^\\/]+$"
+  ],
+
+};
+
+module.exports = config;

--- a/package.json
+++ b/package.json
@@ -28,8 +28,8 @@
     "dep:update": "npx ncu -u"
   },
   "dependencies": {
-    "@mojaloop/sdk-standard-components": "18.3.0",
-    "ajv": "^8.16.0",
+    "@mojaloop/sdk-standard-components": "18.4.0",
+    "ajv": "^8.17.1",
     "async-retry": "^1.3.3",
     "dotenv": "^16.4.5",
     "fast-json-patch": "^3.1.1",
@@ -48,9 +48,9 @@
     "jest": "^29.7.0",
     "jest-junit": "^16.0.0",
     "mockdate": "^3.0.5",
-    "nock": "^13.5.4",
+    "nock": "^13.5.5",
+    "npm-check-updates": "17.0.6",
     "openapi-response-validator": "^12.1.3",
-    "typescript": "^5.5.3",
-    "npm-check-updates": "16.14.20"
+    "typescript": "^5.5.4"
   }
 }


### PR DESCRIPTION
Hello,
I have made some changes in this repository to add the test coverage with a text summary. For this, I needed to install jest globally and configure jest.config.js.

So, I have made changes in the ".gitignore" file, created a jest.config.js file, and updated a few packages along the go.

Now, this is what I am getting as a result, when I run the command `npm test`

![image](https://github.com/user-attachments/assets/8af18c51-23dc-459c-9c1a-06f50a328132)
