### PR TITLE
feat: add code to detect broken connections and terminate clients

### DIFF
--- a/src/lib/ControlServer/Server.ts
+++ b/src/lib/ControlServer/Server.ts
@@ -40,11 +40,6 @@ export interface ServerOpts {
   onRequestPeerJWS: (client: unknown) => void;
   onUploadPeerJWS: (client: unknown) => void;
 }
-interface ClientData {
-  ip: string;
-  logger: Logger.Logger;
-  isAlive: boolean;
-}
 
 class Server extends ws.Server {
   private _logger: Logger.Logger;


### PR DESCRIPTION
https://github.com/websockets/ws?tab=readme-ov-file#how-to-detect-and-close-broken-connections

Possible fix for issue occuring in the sdk where a manual restart is needed to retrieve JWS keys. Assumption being that there is an undetected broken connection.