### PR TITLE
fix: pass kubernetesPath to fix node-vault 0.10.9 regression

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@mojaloop/mcm-client",
-  "version": "4.1.0",
+  "version": "4.1.1-snapshot.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@mojaloop/mcm-client",
-      "version": "4.1.0",
+      "version": "4.1.1-snapshot.0",
       "license": "Apache-2.0",
       "dependencies": {
         "@mojaloop/sdk-standard-components": "^19.18.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@mojaloop/mcm-client",
-  "version": "4.1.0",
+  "version": "4.1.1-snapshot.0",
   "description": "Client service for Connection Manager API",
   "license": "Apache-2.0",
   "main": "dist/index.js",

--- a/src/lib/vault/index.ts
+++ b/src/lib/vault/index.ts
@@ -149,6 +149,7 @@ export default class Vault {
         creds = await vault.kubernetesLogin({
           role: auth.k8s.role,
           jwt: auth.k8s.token,
+          kubernetesPath: 'kubernetes',
         });
       } else {
         const errMessage = 'Unsupported auth method';

--- a/src/test/unit/lib/vault/index.test.ts
+++ b/src/test/unit/lib/vault/index.test.ts
@@ -195,6 +195,7 @@ describe('Vault HTTP Keep-Alive Tests', () => {
         expect(mockVaultClient.kubernetesLogin).toHaveBeenCalledWith({
           role: 'k8s-role',
           jwt: 'k8s-token',
+          kubernetesPath: 'kubernetes',
         });
 
         expect(NodeVault).toHaveBeenNthCalledWith(1, {


### PR DESCRIPTION
node-vault 0.10.9 broke `kubernetesLogin` by using `{{kubernetesPath}}` in the path template but not passing it to mustache, resulting in `/auth//login` (was `/auth/kubernetes/login`) and a 301 error from Vault.
See: https://github.com/nodevault/node-vault/commit/a660d8a